### PR TITLE
Fix problem with Bluebird warnings when promise is rejected

### DIFF
--- a/traverson-promise.js
+++ b/traverson-promise.js
@@ -35,7 +35,6 @@ function promisify (context, originalMethod) {
 
   var deferred = defer()
   var traversal = void 0
-  var resultWithTraversalDeferred = defer()
 
   var callback = function callback (err, result, _traversal) {
     traversal = _traversal
@@ -44,12 +43,8 @@ function promisify (context, originalMethod) {
       err.result = result
       err.traversal = traversal
       deferred.reject(err)
-      // Pass the error and traversal to reject handler on resultWithTraversal
-      resultWithTraversalDeferred.reject(err)
     } else {
       deferred.resolve(result)
-      // Pass the response and traversal to resolve handler on resultWithTraversal
-      resultWithTraversalDeferred.resolve({ result: result, traversal: traversal })
     }
   }
 
@@ -71,7 +66,14 @@ function promisify (context, originalMethod) {
 
   return {
     result: deferred.promise,
-    resultWithTraversal: resultWithTraversalDeferred.promise,
+    resultWithTraversal: function() {
+      return deferred.promise.then(function(result) {
+        return {
+          result: result,
+          traversal: traversal
+        }
+      })
+    },
     continue: continueTraversal,
     abort: traversalHandler.abort,
     then: function then () {


### PR DESCRIPTION
Because `promisify` method returns 2 deferred (deferred, resultWithTraversalDeferred), when request was not successful, it caused an warning from Bluebird `Unhandled rejection HTTPError`



To keep backward compatibility it can be also changed to  (so the `resultWithTraversal` will be object)
```
var callback = function callback (err, result, _traversal) {
    traversal = _traversal

    if (err) {
      resultWithTraversalDeferred.reject = deferred.reject
      deferred.reject(err)

    } else {
      deferred.resolve(result)
      // Pass the response and traversal to resolve handler on resultWithTraversal
      resultWithTraversalDeferred.resolve({ result: result, traversal: traversal })
    }
  }
```

I think the code in PR is better, but IF you want to keep backward compatibility with `resultWithTraversal` its rather better to use code snippet from PR description